### PR TITLE
Add NanoPi R6S build support

### DIFF
--- a/.github/workflows/openwrt-friendlyarm_nanopi-r6s-imagebuilder.yml
+++ b/.github/workflows/openwrt-friendlyarm_nanopi-r6s-imagebuilder.yml
@@ -1,0 +1,95 @@
+name: OpenWrt FriendlyARM NanoPi R6S
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  schedule:
+    - cron: "0 0/12 * * 2-6"
+
+jobs:
+  printJob:
+    name: Print event
+    runs-on: ubuntu-latest
+    steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: |
+        echo "$GITHUB_CONTEXT"
+  check:
+    outputs:
+      latest: ${{ steps.latest.outputs.is_latest }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+      - name: Set Environment Variable
+        run: |
+          OPENWRT_VERSION=`./latest-imagebuilder-version.sh rockchip armv8 .`
+          echo "OPENWRT_VERSION=${OPENWRT_VERSION}" >> $GITHUB_ENV
+      - id: latest
+        name: Check Published Version
+        run: |
+          PUBLISHED_VERSION=`curl 'https://downloads.hackinggate.com' | grep 'nanopi-r6s' | grep -E -o ${OPENWRT_VERSION} | tail -1`
+          echo "${OPENWRT_VERSION} is latest"
+          if [[ "$OPENWRT_VERSION" == "$PUBLISHED_VERSION" ]]; then
+            echo "${OPENWRT_VERSION} is published for nanopi-r6s"
+            echo "::set-output name=is_latest::true"
+          else
+            echo "${OPENWRT_VERSION} is NOT published for nanopi-r6s"
+          fi
+  build:
+    needs: check
+    if: ${{ needs.check.outputs.latest != 'true' || github.event_name != 'schedule' }}
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        major_version: [v]
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+      - name: Set Environment Variable
+        run: |
+          OPENWRT_VERSION=`./latest-imagebuilder-version.sh rockchip armv8 ${{ matrix.major_version }}`
+          echo "OPENWRT_VERSION=${OPENWRT_VERSION}" >> $GITHUB_ENV
+      - name: Prerequisites
+        run: |
+          sudo apt update
+          sudo apt install build-essential clang flex bison g++ gawk gcc-multilib g++-multilib \
+          gettext git libncurses-dev libssl-dev python3-distutils rsync unzip zlib1g-dev \
+          file wget
+      - name: Build NanoPi R6S with imagebuilder
+        run: ./nanopi-r6s-openwrt-imagebuilder-build.sh
+      - name: Checkout gh-pages
+        run : |
+          git config --add remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+          git fetch origin gh-pages
+          git checkout gh-pages
+      - name: Override Files
+        run: |
+          IMAGE_PREFIX=`cat openwrt-imagebuilder-${OPENWRT_VERSION}-rockchip-armv8.Linux-x86_64/bin/targets/rockchip/armv8/profiles.json | jq '.["profiles"]' | jq 'map(.)' | jq -r '.[] | select(.id == "friendlyarm_nanopi-r6s") | .image_prefix'`
+          rm -rf ${IMAGE_PREFIX}
+          mv openwrt-imagebuilder-${OPENWRT_VERSION}-rockchip-armv8.Linux-x86_64/bin/targets/rockchip/armv8 ${IMAGE_PREFIX}
+          rm -rf openwrt-imagebuilder-*
+      - name: Generate gh-pages
+        run: |
+          git checkout - -- generate-page.sh
+          ./generate-page.sh
+          rm generate-page.sh
+      - name: Tree
+        run: | 
+          sudo apt install tree
+          tree
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          branch: gh-pages
+          folder: .
+          clean: true
+          dry-run: ${{ github.event_name == 'pull_request' }}

--- a/latest-imagebuilder-version.sh
+++ b/latest-imagebuilder-version.sh
@@ -4,14 +4,11 @@
 set -e
 
 OPENWRT_VERSION=`curl -s https://api.github.com/repos/openwrt/openwrt/tags | jq -r '.[]["name"]' | grep ${3} | head -1 | grep -E -o '[0-9]+\.[0-9]+\.[0-9]+($|-rc[0-9]+$)'`
-echo "Download OpenWrt Image Builder ${OPENWRT_VERSION}"
 IMAGEBUILDER_HTTP_CODE=`curl -s -o /dev/null --head -w "%{http_code}" https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${1}/${2}/openwrt-imagebuilder-${OPENWRT_VERSION}-${1}-${2}.Linux-x86_64.tar.zst`
-echo "HTTP code: ${IMAGEBUILDER_HTTP_CODE}"
 if [[ "$IMAGEBUILDER_HTTP_CODE" != 200 ]]; then
     echo "Not found for https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${1}/${2}/openwrt-imagebuilder-${OPENWRT_VERSION}-${1}-${2}.Linux-x86_64.tar.zst"
     # Use previous version if imagebuilder not yet available
     OPENWRT_VERSION=`curl -s https://api.github.com/repos/openwrt/openwrt/tags | jq -r '.[1]["name"]' | grep -E -o '[0-9]+\.[0-9]+\.[0-9]+($|-rc[0-9]+$)'`
-    echo "Use previous version ${OPENWRT_VERSION} instead"
 fi
 
 echo ${OPENWRT_VERSION}

--- a/latest-imagebuilder-version.sh
+++ b/latest-imagebuilder-version.sh
@@ -5,10 +5,10 @@ set -e
 
 OPENWRT_VERSION=`curl -s https://api.github.com/repos/openwrt/openwrt/tags | jq -r '.[]["name"]' | grep ${3} | head -1 | grep -E -o '[0-9]+\.[0-9]+\.[0-9]+($|-rc[0-9]+$)'`
 echo "Download OpenWrt Image Builder ${OPENWRT_VERSION}"
-IMAGEBUILDER_HTTP_CODE=`curl -s -o /dev/null --head -w "%{http_code}" https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${1}/${2}/openwrt-imagebuilder-${OPENWRT_VERSION}-${1}-${2}.Linux-x86_64.tar.xz`
+IMAGEBUILDER_HTTP_CODE=`curl -s -o /dev/null --head -w "%{http_code}" https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${1}/${2}/openwrt-imagebuilder-${OPENWRT_VERSION}-${1}-${2}.Linux-x86_64.tar.zst`
 echo "HTTP code: ${IMAGEBUILDER_HTTP_CODE}"
 if [[ "$IMAGEBUILDER_HTTP_CODE" != 200 ]]; then
-    echo "Not found for https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${1}/${2}/openwrt-imagebuilder-${OPENWRT_VERSION}-${1}-${2}.Linux-x86_64.tar.xz"
+    echo "Not found for https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${1}/${2}/openwrt-imagebuilder-${OPENWRT_VERSION}-${1}-${2}.Linux-x86_64.tar.zst"
     # Use previous version if imagebuilder not yet available
     OPENWRT_VERSION=`curl -s https://api.github.com/repos/openwrt/openwrt/tags | jq -r '.[1]["name"]' | grep -E -o '[0-9]+\.[0-9]+\.[0-9]+($|-rc[0-9]+$)'`
     echo "Use previous version ${OPENWRT_VERSION} instead"

--- a/nanopi-r6s-openwrt-imagebuilder-build.sh
+++ b/nanopi-r6s-openwrt-imagebuilder-build.sh
@@ -28,6 +28,7 @@ sed -i 's/http:/https:/g' .config repositories.conf
 # Make all kernel modules built-in
 sed -i -e "s/=m/=y/g" build_dir/target-aarch64_generic_musl/linux-${TARGET}_${SUBTARGET}/linux-*/.config
 
+# https://openwrt.org/docs/guide-user/advanced/expand_root
 # Create custom files directory structure for filesystem expansion
 mkdir -p files/etc/uci-defaults
 

--- a/nanopi-r6s-openwrt-imagebuilder-build.sh
+++ b/nanopi-r6s-openwrt-imagebuilder-build.sh
@@ -11,11 +11,11 @@ DEVICE_NAME='friendlyarm_nanopi-r6s'
 echo "Download OpenWrt Image Builder ${OPENWRT_VERSION}"
 
 # Download imagebuilder for NanoPi R6S.
-aria2c -c -x4 -s4 https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${TARGET}/${SUBTARGET}/openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.xz
+aria2c -c -x4 -s4 https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${TARGET}/${SUBTARGET}/openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.zst
 
 # Extract & remove used file & cd to the directory
-tar -xvf openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.xz
-rm openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.xz
+tar -xvf openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.zst
+rm openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.zst
 cd openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64/
 
 # Replace image files with custom 32GB eMMC configuration

--- a/nanopi-r6s-openwrt-imagebuilder-build.sh
+++ b/nanopi-r6s-openwrt-imagebuilder-build.sh
@@ -42,7 +42,7 @@ PACKAGES="base-files dropbear libc logd mtd opkg procd-ujail uboot-envtools uci 
 ca-bundle ca-certificates libustream-mbedtls \
 -dnsmasq dnsmasq-full odhcp6c odhcpd-ipv6only ppp ppp-mod-pppoe 6in4 https-dns-proxy luci-proto-wireguard \
 kmod-fs-ext4 kmod-gpio-button-hotplug kmod-r8169 kmod-usb-storage kmod-usb-storage-uas kernel \
-block-mount e2fsprogs mkf2fs partx-utils resize2fs \
+block-mount e2fsprogs mkf2fs partx-utils resize2fs fdisk lsblk losetup blockdev \
 luci luci-app-aria2 luci-app-attendedsysupgrade luci-app-cloudflared luci-app-https-dns-proxy luci-app-samba4 luci-app-statistics \
 collectd-mod-ping collectd-mod-wireless \
 aria2 ariang samba4-server tailscale \

--- a/nanopi-r6s-openwrt-imagebuilder-build.sh
+++ b/nanopi-r6s-openwrt-imagebuilder-build.sh
@@ -28,10 +28,10 @@ sed -i 's/http:/https:/g' .config repositories.conf
 sed -i -e "s/=m/=y/g" build_dir/target-aarch64_generic_musl/linux-${TARGET}_${SUBTARGET}/linux-*/.config
 
 # Run the final build configuration
-make image PROFILE=${DEVICE_NAME} \
+make -j$(nproc) image PROFILE=${DEVICE_NAME} \
 PACKAGES="base-files dropbear libc logd mtd opkg procd-ujail uboot-envtools uci urandom-seed urngd \
 ca-bundle ca-certificates libustream-mbedtls \
-dnsmasq-full odhcp6c odhcpd-ipv6only ppp ppp-mod-pppoe 6in4 https-dns-proxy luci-proto-wireguard \
+-dnsmasq dnsmasq-full odhcp6c odhcpd-ipv6only ppp ppp-mod-pppoe 6in4 https-dns-proxy luci-proto-wireguard \
 kmod-fs-ext4 kmod-gpio-button-hotplug kmod-r8169 kmod-usb-storage kmod-usb-storage-uas kernel \
 block-mount e2fsprogs mkf2fs partx-utils resize2fs \
 luci luci-app-aria2 luci-app-attendedsysupgrade luci-app-cloudflared luci-app-https-dns-proxy luci-app-samba4 luci-app-statistics \

--- a/nanopi-r6s-openwrt-imagebuilder-build.sh
+++ b/nanopi-r6s-openwrt-imagebuilder-build.sh
@@ -18,11 +18,8 @@ tar -xvf openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x8
 rm openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.zst
 cd openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64/
 
-# Replace image files with custom 32GB eMMC configuration
-cd target/linux/${TARGET}/image
-wget https://github.com/HackingGate/openwrt/raw/openwrt-${OPENWRT_MAJOR_VERSION}-modified-device/target/linux/${TARGET}/image/Makefile -O Makefile
-wget https://github.com/HackingGate/openwrt/raw/openwrt-${OPENWRT_MAJOR_VERSION}-modified-device/target/linux/${TARGET}/image/armv8.mk -O armv8.mk
-cd -
+# Configure rootfs partition size (1GB = 1024MB)
+sed -i 's/CONFIG_TARGET_ROOTFS_PARTSIZE=104/CONFIG_TARGET_ROOTFS_PARTSIZE=32768/' .config
 
 # Use https
 sed -i 's/http:/https:/g' .config repositories.conf

--- a/nanopi-r6s-openwrt-imagebuilder-build.sh
+++ b/nanopi-r6s-openwrt-imagebuilder-build.sh
@@ -35,15 +35,14 @@ make image PROFILE=${DEVICE_NAME} \
 PACKAGES="luci ca-bundle ca-certificates \
 -dnsmasq dnsmasq-full \
 https-dns-proxy luci-app-https-dns-proxy \
-luci-app-wireguard luci-proto-wireguard 6in4 \
-ddns-scripts ddns-scripts-cloudflare luci-app-ddns \
+luci-proto-wireguard 6in4 \
 luci-app-cloudflared tailscale \
 block-mount e2fsprogs kmod-fs-ext4 resize2fs \
 kmod-usb-storage kmod-usb-storage-uas usbutils \
 samba4-server luci-app-samba4 \
 aria2 luci-app-aria2 ariang \
 luci-app-statistics collectd-mod-cpu collectd-mod-interface collectd-mod-memory collectd-mod-ping collectd-mod-rrdtool collectd-mod-wireless \
-auc luci-app-attendedsysupgrade \
+luci-app-attendedsysupgrade \
 kmod-r8169 \
 bind-host curl wget tcpdump \
 diffutils git map bash tar vim"

--- a/nanopi-r6s-openwrt-imagebuilder-build.sh
+++ b/nanopi-r6s-openwrt-imagebuilder-build.sh
@@ -28,13 +28,74 @@ sed -i 's/http:/https:/g' .config repositories.conf
 # Make all kernel modules built-in
 sed -i -e "s/=m/=y/g" build_dir/target-aarch64_generic_musl/linux-${TARGET}_${SUBTARGET}/linux-*/.config
 
+# Create custom files directory structure for filesystem expansion
+mkdir -p files/etc/uci-defaults
+
+# Create the official OpenWrt root partition expansion script
+cat << "EOF" > files/etc/uci-defaults/70-rootpt-resize
+if [ ! -e /etc/rootpt-resize ] \
+&& type parted > /dev/null \
+&& lock -n /var/lock/root-resize
+then
+ROOT_BLK="$(readlink -f /sys/dev/block/"$(awk -e \
+'$9=="/dev/root"{print $3}' /proc/self/mountinfo)")"
+ROOT_DISK="/dev/$(basename "${ROOT_BLK%/*}")"
+ROOT_PART="${ROOT_BLK##*[^0-9]}"
+parted -f -s "${ROOT_DISK}" \
+resizepart "${ROOT_PART}" 100%
+mount_root done
+touch /etc/rootpt-resize
+ 
+if [ -e /boot/cmdline.txt ]
+then 
+NEW_UUID=`blkid ${ROOT_DISK}p${ROOT_PART} | sed -n 's/.*PARTUUID="\([^"]*\)".*/\1/p'`
+sed -i "s/PARTUUID=[^ ]*/PARTUUID=${NEW_UUID}/" /boot/cmdline.txt
+fi
+ 
+reboot
+fi
+exit 1
+EOF
+
+# Create the official OpenWrt root filesystem expansion script
+cat << "EOF" > files/etc/uci-defaults/80-rootfs-resize
+if [ ! -e /etc/rootfs-resize ] \
+&& [ -e /etc/rootpt-resize ] \
+&& type losetup > /dev/null \
+&& type resize2fs > /dev/null \
+&& lock -n /var/lock/root-resize
+then
+ROOT_BLK="$(readlink -f /sys/dev/block/"$(awk -e \
+'$9=="/dev/root"{print $3}' /proc/self/mountinfo)")"
+ROOT_DEV="/dev/${ROOT_BLK##*/}"
+LOOP_DEV="$(awk -e '$5=="/overlay"{print $9}' \
+/proc/self/mountinfo)"
+if [ -z "${LOOP_DEV}" ]
+then
+LOOP_DEV="$(losetup -f)"
+losetup "${LOOP_DEV}" "${ROOT_DEV}"
+fi
+resize2fs -f "${LOOP_DEV}"
+mount_root done
+touch /etc/rootfs-resize
+reboot
+fi
+exit 1
+EOF
+
+# Create sysupgrade.conf to preserve expansion scripts across firmware upgrades
+cat << "EOF" > files/etc/sysupgrade.conf
+/etc/uci-defaults/70-rootpt-resize
+/etc/uci-defaults/80-rootfs-resize
+EOF
+
 # Run the final build configuration
 make -j$(nproc) image PROFILE=${DEVICE_NAME} \
 PACKAGES="base-files dropbear libc logd mtd opkg procd-ujail uboot-envtools uci urandom-seed urngd \
 ca-bundle ca-certificates libustream-mbedtls \
 -dnsmasq dnsmasq-full odhcp6c odhcpd-ipv6only ppp ppp-mod-pppoe 6in4 https-dns-proxy luci-proto-wireguard \
 kmod-fs-ext4 kmod-gpio-button-hotplug kmod-r8169 kmod-usb-storage kmod-usb-storage-uas kernel \
-block-mount e2fsprogs mkf2fs partx-utils resize2fs f2fs-tools fdisk lsblk losetup blockdev \
+block-mount e2fsprogs mkf2fs partx-utils resize2fs f2fs-tools fdisk lsblk losetup blockdev parted blkid \
 luci luci-app-aria2 luci-app-attendedsysupgrade luci-app-cloudflared luci-app-https-dns-proxy luci-app-samba4 luci-app-statistics \
 collectd-mod-ping collectd-mod-wireless \
 aria2 ariang samba4-server tailscale \

--- a/nanopi-r6s-openwrt-imagebuilder-build.sh
+++ b/nanopi-r6s-openwrt-imagebuilder-build.sh
@@ -29,18 +29,22 @@ sed -i -e "s/=m/=y/g" build_dir/target-aarch64_generic_musl/linux-${TARGET}_${SU
 
 # Run the final build configuration
 make image PROFILE=${DEVICE_NAME} \
-PACKAGES="luci ca-bundle ca-certificates \
+PACKAGES="base-files ca-bundle dnsmasq dropbear e2fsprogs firewall4 fstools \
+kmod-gpio-button-hotplug kmod-nft-offload libc libgcc libustream-mbedtls logd \
+mkf2fs mtd netifd nftables odhcp6c odhcpd-ipv6only opkg partx-utils ppp \
+ppp-mod-pppoe procd-ujail uboot-envtools uci uclient-fetch urandom-seed urngd \
+kmod-r8169 luci \
+ca-certificates \
 -dnsmasq dnsmasq-full \
 https-dns-proxy luci-app-https-dns-proxy \
 luci-proto-wireguard 6in4 \
 luci-app-cloudflared tailscale \
-block-mount e2fsprogs kmod-fs-ext4 resize2fs \
+block-mount kmod-fs-ext4 resize2fs \
 kmod-usb-storage kmod-usb-storage-uas usbutils \
 samba4-server luci-app-samba4 \
 aria2 luci-app-aria2 ariang \
 luci-app-statistics collectd-mod-cpu collectd-mod-interface collectd-mod-memory collectd-mod-ping collectd-mod-rrdtool collectd-mod-wireless \
 luci-app-attendedsysupgrade \
-kmod-r8169 \
 bind-host curl wget tcpdump \
 diffutils git map bash tar vim"
 

--- a/nanopi-r6s-openwrt-imagebuilder-build.sh
+++ b/nanopi-r6s-openwrt-imagebuilder-build.sh
@@ -19,7 +19,7 @@ rm openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.t
 cd openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64/
 
 # Configure rootfs partition size (1GB = 1024MB)
-sed -i 's/CONFIG_TARGET_ROOTFS_PARTSIZE=104/CONFIG_TARGET_ROOTFS_PARTSIZE=256/' .config
+sed -i 's/CONFIG_TARGET_ROOTFS_PARTSIZE=104/CONFIG_TARGET_ROOTFS_PARTSIZE=232/' .config
 
 # Use https
 sed -i 's/http:/https:/g' .config repositories.conf
@@ -42,7 +42,7 @@ PACKAGES="base-files dropbear libc logd mtd opkg procd-ujail uboot-envtools uci 
 ca-bundle ca-certificates libustream-mbedtls \
 -dnsmasq dnsmasq-full odhcp6c odhcpd-ipv6only ppp ppp-mod-pppoe 6in4 https-dns-proxy luci-proto-wireguard \
 kmod-fs-ext4 kmod-gpio-button-hotplug kmod-r8169 kmod-usb-storage kmod-usb-storage-uas kernel \
-block-mount e2fsprogs mkf2fs partx-utils resize2fs util-linux \
+block-mount e2fsprogs mkf2fs partx-utils resize2fs \
 luci luci-app-aria2 luci-app-attendedsysupgrade luci-app-cloudflared luci-app-https-dns-proxy luci-app-samba4 luci-app-statistics \
 collectd-mod-ping collectd-mod-wireless \
 aria2 ariang samba4-server tailscale \

--- a/nanopi-r6s-openwrt-imagebuilder-build.sh
+++ b/nanopi-r6s-openwrt-imagebuilder-build.sh
@@ -29,24 +29,15 @@ sed -i -e "s/=m/=y/g" build_dir/target-aarch64_generic_musl/linux-${TARGET}_${SU
 
 # Run the final build configuration
 make image PROFILE=${DEVICE_NAME} \
-PACKAGES="base-files ca-bundle dnsmasq dropbear e2fsprogs firewall4 fstools \
-kmod-gpio-button-hotplug kmod-nft-offload libc libgcc libustream-mbedtls logd \
-mkf2fs mtd netifd nftables odhcp6c odhcpd-ipv6only opkg partx-utils ppp \
-ppp-mod-pppoe procd-ujail uboot-envtools uci uclient-fetch urandom-seed urngd \
-kmod-r8169 luci \
-ca-certificates \
--dnsmasq dnsmasq-full \
-https-dns-proxy luci-app-https-dns-proxy \
-luci-proto-wireguard 6in4 \
-luci-app-cloudflared tailscale \
-block-mount kmod-fs-ext4 resize2fs \
-kmod-usb-storage kmod-usb-storage-uas usbutils \
-samba4-server luci-app-samba4 \
-aria2 luci-app-aria2 ariang \
-luci-app-statistics collectd-mod-cpu collectd-mod-interface collectd-mod-memory collectd-mod-ping collectd-mod-rrdtool collectd-mod-wireless \
-luci-app-attendedsysupgrade \
-bind-host curl wget tcpdump \
-diffutils git map bash tar vim"
+PACKAGES="base-files dropbear libc logd mtd opkg procd-ujail uboot-envtools uci urandom-seed urngd \
+ca-bundle ca-certificates libustream-mbedtls \
+dnsmasq-full odhcp6c odhcpd-ipv6only ppp ppp-mod-pppoe 6in4 https-dns-proxy luci-proto-wireguard \
+kmod-fs-ext4 kmod-gpio-button-hotplug kmod-r8169 kmod-usb-storage kmod-usb-storage-uas kernel \
+block-mount e2fsprogs mkf2fs partx-utils resize2fs \
+luci luci-app-aria2 luci-app-attendedsysupgrade luci-app-cloudflared luci-app-https-dns-proxy luci-app-samba4 luci-app-statistics \
+collectd-mod-ping collectd-mod-wireless \
+aria2 ariang samba4-server tailscale \
+bash bind-host curl diffutils git map tar tcpdump usbutils vim"
 
 # Result
 cd bin/targets/${TARGET}/${SUBTARGET}/

--- a/nanopi-r6s-openwrt-imagebuilder-build.sh
+++ b/nanopi-r6s-openwrt-imagebuilder-build.sh
@@ -98,7 +98,7 @@ make -j$(nproc) image \
 PROFILE=${DEVICE_NAME} \
 FILES="files" \
 PACKAGES="base-files dropbear libc logd mtd opkg procd-ujail uboot-envtools uci urandom-seed urngd \
-ca-bundle ca-certificates libustream-mbedtls \
+ca-bundle ca-certificates -libustream-mbedtls libustream-openssl openssl-util \
 -dnsmasq dnsmasq-full odhcp6c odhcpd-ipv6only ppp ppp-mod-pppoe 6in4 https-dns-proxy luci-proto-wireguard \
 kmod-fs-ext4 kmod-gpio-button-hotplug kmod-r8169 kmod-usb-storage kmod-usb-storage-uas kernel \
 block-mount e2fsprogs mkf2fs partx-utils resize2fs f2fs-tools fdisk lsblk losetup blockdev parted blkid \

--- a/nanopi-r6s-openwrt-imagebuilder-build.sh
+++ b/nanopi-r6s-openwrt-imagebuilder-build.sh
@@ -18,8 +18,9 @@ tar -xvf openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x8
 rm openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.zst
 cd openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64/
 
-# Configure rootfs partition size (1GB = 1024MB)
-sed -i 's/CONFIG_TARGET_ROOTFS_PARTSIZE=104/CONFIG_TARGET_ROOTFS_PARTSIZE=232/' .config
+# Configure partition sizes for faster builds
+sed -i 's/CONFIG_TARGET_KERNEL_PARTSIZE=16/CONFIG_TARGET_KERNEL_PARTSIZE=128/' .config
+sed -i 's/CONFIG_TARGET_ROOTFS_PARTSIZE=104/CONFIG_TARGET_ROOTFS_PARTSIZE=512/' .config
 
 # Use https
 sed -i 's/http:/https:/g' .config repositories.conf
@@ -42,7 +43,7 @@ PACKAGES="base-files dropbear libc logd mtd opkg procd-ujail uboot-envtools uci 
 ca-bundle ca-certificates libustream-mbedtls \
 -dnsmasq dnsmasq-full odhcp6c odhcpd-ipv6only ppp ppp-mod-pppoe 6in4 https-dns-proxy luci-proto-wireguard \
 kmod-fs-ext4 kmod-gpio-button-hotplug kmod-r8169 kmod-usb-storage kmod-usb-storage-uas kernel \
-block-mount e2fsprogs mkf2fs partx-utils resize2fs fdisk lsblk losetup blockdev \
+block-mount e2fsprogs mkf2fs partx-utils resize2fs f2fs-tools fdisk lsblk losetup blockdev \
 luci luci-app-aria2 luci-app-attendedsysupgrade luci-app-cloudflared luci-app-https-dns-proxy luci-app-samba4 luci-app-statistics \
 collectd-mod-ping collectd-mod-wireless \
 aria2 ariang samba4-server tailscale \

--- a/nanopi-r6s-openwrt-imagebuilder-build.sh
+++ b/nanopi-r6s-openwrt-imagebuilder-build.sh
@@ -19,7 +19,7 @@ rm openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.t
 cd openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64/
 
 # Configure rootfs partition size (1GB = 1024MB)
-sed -i 's/CONFIG_TARGET_ROOTFS_PARTSIZE=104/CONFIG_TARGET_ROOTFS_PARTSIZE=32768/' .config
+sed -i 's/CONFIG_TARGET_ROOTFS_PARTSIZE=104/CONFIG_TARGET_ROOTFS_PARTSIZE=256/' .config
 
 # Use https
 sed -i 's/http:/https:/g' .config repositories.conf
@@ -27,13 +27,22 @@ sed -i 's/http:/https:/g' .config repositories.conf
 # Make all kernel modules built-in
 sed -i -e "s/=m/=y/g" build_dir/target-aarch64_generic_musl/linux-${TARGET}_${SUBTARGET}/linux-*/.config
 
+# Create custom files directory structure for filesystem expansion
+mkdir -p files/etc/uci-defaults
+
+# Download the filesystem expansion script directly to uci-defaults
+curl -o files/etc/uci-defaults/99-expand-rootfs https://gist.githubusercontent.com/HackingGate/98f80db3645a3c383ea4fa179aaa4e25/raw/f2c27da2bbb53a35556100367b03f9b650766bd8/expand_rootfs.sh
+
+# Make the script executable
+chmod +x files/etc/uci-defaults/99-expand-rootfs
+
 # Run the final build configuration
 make -j$(nproc) image PROFILE=${DEVICE_NAME} \
 PACKAGES="base-files dropbear libc logd mtd opkg procd-ujail uboot-envtools uci urandom-seed urngd \
 ca-bundle ca-certificates libustream-mbedtls \
 -dnsmasq dnsmasq-full odhcp6c odhcpd-ipv6only ppp ppp-mod-pppoe 6in4 https-dns-proxy luci-proto-wireguard \
 kmod-fs-ext4 kmod-gpio-button-hotplug kmod-r8169 kmod-usb-storage kmod-usb-storage-uas kernel \
-block-mount e2fsprogs mkf2fs partx-utils resize2fs \
+block-mount e2fsprogs mkf2fs partx-utils resize2fs util-linux \
 luci luci-app-aria2 luci-app-attendedsysupgrade luci-app-cloudflared luci-app-https-dns-proxy luci-app-samba4 luci-app-statistics \
 collectd-mod-ping collectd-mod-wireless \
 aria2 ariang samba4-server tailscale \

--- a/nanopi-r6s-openwrt-imagebuilder-build.sh
+++ b/nanopi-r6s-openwrt-imagebuilder-build.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Exit immediately if a simple command exits with a non-zero status
+set -e
+
+OPENWRT_MAJOR_VERSION=`echo ${OPENWRT_VERSION} | grep -E -o '[0-9]+\.[0-9]+'`
+TARGET='rockchip'
+SUBTARGET='armv8'
+DEVICE_NAME='friendlyarm_nanopi-r6s'
+
+echo "Download OpenWrt Image Builder ${OPENWRT_VERSION}"
+
+# Download imagebuilder for NanoPi R6S.
+aria2c -c -x4 -s4 https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${TARGET}/${SUBTARGET}/openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.xz
+
+# Extract & remove used file & cd to the directory
+tar -xvf openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.xz
+rm openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.xz
+cd openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64/
+
+# Replace image files with custom 32GB eMMC configuration
+cd target/linux/${TARGET}/image
+wget https://github.com/HackingGate/openwrt/raw/openwrt-${OPENWRT_MAJOR_VERSION}-modified-device/target/linux/${TARGET}/image/Makefile -O Makefile
+wget https://github.com/HackingGate/openwrt/raw/openwrt-${OPENWRT_MAJOR_VERSION}-modified-device/target/linux/${TARGET}/image/armv8.mk -O armv8.mk
+cd -
+
+# Use https
+sed -i 's/http:/https:/g' .config repositories.conf
+
+# Make all kernel modules built-in
+sed -i -e "s/=m/=y/g" build_dir/target-aarch64_generic_musl/linux-${TARGET}_${SUBTARGET}/linux-*/.config
+
+# Run the final build configuration
+make image PROFILE=${DEVICE_NAME} \
+PACKAGES="luci ca-bundle ca-certificates \
+-dnsmasq dnsmasq-full \
+https-dns-proxy luci-app-https-dns-proxy \
+luci-app-wireguard luci-proto-wireguard 6in4 \
+ddns-scripts ddns-scripts-cloudflare luci-app-ddns \
+luci-app-cloudflared tailscale \
+block-mount e2fsprogs kmod-fs-ext4 resize2fs \
+kmod-usb-storage kmod-usb-storage-uas usbutils \
+samba4-server luci-app-samba4 \
+aria2 luci-app-aria2 ariang \
+luci-app-statistics collectd-mod-cpu collectd-mod-interface collectd-mod-memory collectd-mod-ping collectd-mod-rrdtool collectd-mod-wireless \
+auc luci-app-attendedsysupgrade \
+kmod-r8169 \
+bind-host curl wget tcpdump \
+diffutils git map bash tar vim"
+
+# Result
+cd bin/targets/${TARGET}/${SUBTARGET}/
+cat profiles.json | jq
+cat sha256sums

--- a/nanopi-r6s-openwrt-imagebuilder-build.sh
+++ b/nanopi-r6s-openwrt-imagebuilder-build.sh
@@ -90,7 +90,12 @@ cat << "EOF" > files/etc/sysupgrade.conf
 EOF
 
 # Run the final build configuration
-make -j$(nproc) image PROFILE=${DEVICE_NAME} \
+# https://openwrt.org/docs/guide-user/additional-software/imagebuilder
+#  The list of currently installed packages on your device can be obtained with the following command:
+# echo $(opkg list-installed | sed -e "s/\s.*$//")
+make -j$(nproc) image \
+PROFILE=${DEVICE_NAME} \
+FILES="files" \
 PACKAGES="base-files dropbear libc logd mtd opkg procd-ujail uboot-envtools uci urandom-seed urngd \
 ca-bundle ca-certificates libustream-mbedtls \
 -dnsmasq dnsmasq-full odhcp6c odhcpd-ipv6only ppp ppp-mod-pppoe 6in4 https-dns-proxy luci-proto-wireguard \

--- a/nanopi-r6s-openwrt-imagebuilder-build.sh
+++ b/nanopi-r6s-openwrt-imagebuilder-build.sh
@@ -28,15 +28,6 @@ sed -i 's/http:/https:/g' .config repositories.conf
 # Make all kernel modules built-in
 sed -i -e "s/=m/=y/g" build_dir/target-aarch64_generic_musl/linux-${TARGET}_${SUBTARGET}/linux-*/.config
 
-# Create custom files directory structure for filesystem expansion
-mkdir -p files/etc/uci-defaults
-
-# Download the filesystem expansion script directly to uci-defaults
-curl -o files/etc/uci-defaults/99-expand-rootfs https://gist.githubusercontent.com/HackingGate/98f80db3645a3c383ea4fa179aaa4e25/raw/f2c27da2bbb53a35556100367b03f9b650766bd8/expand_rootfs.sh
-
-# Make the script executable
-chmod +x files/etc/uci-defaults/99-expand-rootfs
-
 # Run the final build configuration
 make -j$(nproc) image PROFILE=${DEVICE_NAME} \
 PACKAGES="base-files dropbear libc logd mtd opkg procd-ujail uboot-envtools uci urandom-seed urngd \

--- a/r7800-openwrt-imagebuilder-build.sh
+++ b/r7800-openwrt-imagebuilder-build.sh
@@ -6,11 +6,11 @@ set -e
 echo "Download OpenWrt Image Builder ${OPENWRT_VERSION}"
 
 # Download imagebuilder for R7800.
-aria2c -c -x4 -s4 https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/ipq806x/generic/openwrt-imagebuilder-${OPENWRT_VERSION}-ipq806x-generic.Linux-x86_64.tar.xz
+aria2c -c -x4 -s4 https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/ipq806x/generic/openwrt-imagebuilder-${OPENWRT_VERSION}-ipq806x-generic.Linux-x86_64.tar.zst
 
 # Extract & remove used file & cd to the directory
-tar -xvf openwrt-imagebuilder-${OPENWRT_VERSION}-ipq806x-generic.Linux-x86_64.tar.xz
-rm openwrt-imagebuilder-${OPENWRT_VERSION}-ipq806x-generic.Linux-x86_64.tar.xz
+tar -xvf openwrt-imagebuilder-${OPENWRT_VERSION}-ipq806x-generic.Linux-x86_64.tar.zst
+rm openwrt-imagebuilder-${OPENWRT_VERSION}-ipq806x-generic.Linux-x86_64.tar.zst
 cd openwrt-imagebuilder-${OPENWRT_VERSION}-ipq806x-generic.Linux-x86_64/
 
 # Use https

--- a/r7800-openwrt-imagebuilder-build.sh
+++ b/r7800-openwrt-imagebuilder-build.sh
@@ -26,9 +26,7 @@ https-dns-proxy luci-app-https-dns-proxy \
 -wpad-mini -wpad-basic -wpad-basic-wolfssl -wpad-basic-mbedtls wpad-mbedtls usbutils block-mount e2fsprogs samba4-server luci-app-samba4 \
 aria2 luci-app-aria2 ariang curl wget kmod-fs-ext4 kmod-usb-storage kmod-usb-storage-uas \
 luci-app-statistics collectd-mod-cpu collectd-mod-interface collectd-mod-memory collectd-mod-ping collectd-mod-rrdtool collectd-mod-wireless \
--dnsmasq dnsmasq-full luci-app-wireguard luci-proto-wireguard 6in4 \
-ddns-scripts ddns-scripts-cloudflare luci-app-ddns bind-host diffutils git \
-auc luci-app-attendedsysupgrade"
+-dnsmasq dnsmasq-full luci-proto-wireguard tailscale 6in4 git luci-app-attendedsysupgrade"
 
 # Result
 cd bin/targets/ipq806x/generic/

--- a/tl-wr703n-openwrt-imagebuilder-build.sh
+++ b/tl-wr703n-openwrt-imagebuilder-build.sh
@@ -18,11 +18,11 @@ fi
 echo "Download OpenWrt Image Builder ${OPENWRT_VERSION}"
 
 # Download imagebuilder for TL-WR703N.
-aria2c -c -x4 -s4 https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${TARGET}/${SUBTARGET}/openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.xz
+aria2c -c -x4 -s4 https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${TARGET}/${SUBTARGET}/openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.zst
 
 # Extract & remove used file & cd to the directory
-tar -xvf openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.xz
-rm openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.xz
+tar -xvf openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.zst
+rm openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.zst
 cd openwrt-imagebuilder-${OPENWRT_VERSION}-${TARGET}-${SUBTARGET}.Linux-x86_64/
 
 # Replace tiny-tp-link.mk


### PR DESCRIPTION
- Add nanopi-r6s-openwrt-imagebuilder-build.sh for FriendlyARM NanoPi R6S
- Support rockchip/armv8 target with 32GB eMMC configuration
- Include comprehensive package list with VPN, storage, and utility tools
- Add GitHub Actions workflow for automated CI builds
- Pull custom image configuration from openwrt-24.10-modified-device branch